### PR TITLE
fix tester.Dockerfile to build properly

### DIFF
--- a/build/tester.Dockerfile
+++ b/build/tester.Dockerfile
@@ -6,12 +6,13 @@ RUN ln -s /usr/local/go/bin/* /usr/local/bin
 RUN go version
 ENV GOPATH /go
 RUN apt update
-RUN apt install -y git
+RUN apt install -y git autotools-dev automake libtool
 RUN git clone --recursive https://github.com/RedisTimeSeries/RedisTimeSeries.git /go/redis-timeseries
 WORKDIR /go/redis-timeseries
 RUN ./deps/readies/bin/getpy3
-RUN ./system-setup.py
+RUN ./deps/readies/bin/system-setup.py
 RUN python3 ./deps/readies/bin/getredis -v6 --force
+RUN python3 ./deps/readies/bin/getcmake
 RUN make build
 
 RUN set -e ;\


### PR DESCRIPTION
Currently this file from master branch affect circle ci build: https://app.circleci.com/pipelines/github/RedisTimeSeries/prometheus-redistimeseries-adapter/1335/workflows/6b4e7f18-4037-44de-97b0-d287c792368b/jobs/1570

This fix should fix all problems with this tests. Tested on local environment.