### PR TITLE
fix/prometheus-update: up prometheus version

### DIFF
--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   prometheus:
-    image: "prom/prometheus:v2.8.0"
+    image: "prom/prometheus:v2.41.0"
     command: ["--config.file=/prometheus.yml"]
     volumes:
       - ./prometheus.yaml:/prometheus.yml


### PR DESCRIPTION
Used prometheus version v2.8.0 have issue with $__rate_interval as described in issue https://github.com/grafana/grafana/issues/44251 after update to v2.41.0 all is fine. I'm suggest to update default used version to avoid similar issues. 